### PR TITLE
Multi-Rails version specs, Travis CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test/dummy/db/*.sqlite3
 test/dummy/log/*.log
 test/dummy/tmp/
 Gemfile.lock
+gemfiles/*.lock
 *.gem
 nbproject
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+gemfile:
+  - gemfiles/rails_3_1.gemfile
+  - gemfiles/rails_3_2.gemfile
+  - gemfiles/rails_4_0.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,9 @@
 source "http://rubygems.org"
 
-gem "rails", ">= 3.0.0"
-gem "capybara", ">= 0.4.0"
-gem "sqlite3"
+gemspec
 
-gem "rqrcode"
-gem "mini_magick"
+gem 'sqlite3', :platform => :ruby
+gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0', :platform => :jruby
 
 # To use debugger (ruby-debug for Ruby 1.8.7+, ruby-debug19 for Ruby 1.9.2+)
 # gem 'ruby-debug'

--- a/gemfiles/rails_3_1.gemfile
+++ b/gemfiles/rails_3_1.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gemspec :path => '../'
+
+gem 'rails', '~> 3.1.12'
+gem 'sqlite3'

--- a/gemfiles/rails_3_2.gemfile
+++ b/gemfiles/rails_3_2.gemfile
@@ -1,0 +1,7 @@
+source "http://rubygems.org"
+
+gemspec :path => '../'
+
+gem 'rails', '~> 3.2.15'
+gem 'sqlite3'
+

--- a/gemfiles/rails_4_0.gemfile
+++ b/gemfiles/rails_4_0.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gemspec :path => '../'
+
+gem 'rails', '~> 4.0.2'
+gem 'sqlite3'

--- a/lib/rqrcode-rails3.rb
+++ b/lib/rqrcode-rails3.rb
@@ -21,7 +21,8 @@ module RQRCode
     if format && format == :svg
       svg
     else
-      image = MiniMagick::Image.read(svg) { |i| i.format "svg" }
+      require 'mini_magick'
+      image = ::MiniMagick::Image.read(svg) { |i| i.format "svg" }
       image.format format
       image.to_blob
     end

--- a/rqrcode_rails3.gemspec
+++ b/rqrcode_rails3.gemspec
@@ -12,5 +12,8 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/samvincent/rqrcode-rails3"
   s.version     = "0.1.7"
 
-  s.add_dependency 'rqrcode', '>= 0.4.2'
+  s.add_dependency              'rqrcode', '>= 0.4.2'
+  s.add_development_dependency  'capybara', '>= 2.2.0'
+  s.add_development_dependency  'rails', '>= 3.1'
+  s.add_development_dependency  'mini_magick'
 end

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -22,5 +22,7 @@ Dummy::Application.configure do
 
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
+
+  config.eager_load = true
 end
 

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -7,9 +7,6 @@ Dummy::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
@@ -32,4 +29,6 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  config.eager_load = false
 end

--- a/test/support/integration_case.rb
+++ b/test/support/integration_case.rb
@@ -1,5 +1,5 @@
 # Define a bare test case to use with Capybara
 class ActiveSupport::IntegrationCase < ActiveSupport::TestCase
-  include Capybara
+  include Capybara::DSL
   include Rails.application.routes.url_helpers
 end


### PR DESCRIPTION
1. Added gemfiles for multiple Rails minor versions.
2. Updated versions in gemspec to supported/recent versions. (Rails 3.0.x doesn't work, for example)
3. Eliminated various deprecation warnings.
4. Added .travis.yml file.

Once this PR is merged @samvincent will still need to enable Travis CI for the repo at travis-ci.org.
